### PR TITLE
libgrpc 1.62.2 rebuild w/ re2 2024.02.01

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     - patches/0010-for-main-targets-set-_DLL_EXPORTS-when-building-and-.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -77,7 +77,7 @@ outputs:
         - libabseil 20240116.2
         - c-ares 1.19.1
         - libprotobuf 4.25.3
-        - re2 2022.04.01
+        - re2 2024.02.01
         - openssl {{ openssl }}
         - zlib {{ zlib }}
       run:


### PR DESCRIPTION
libgrpc 1.62.2

**Destination channel:** defaults

### Links

- [PKG-6904]
- https://github.com/grpc/grpc/tree/v1.62.2

### Explanation of changes:

- bump build number and use `re2 2024.02.01`

### Notes

- The build fails at link time. The `re2` is not found (`ld: library not found for -lre2` while CMAKE does find it `Found RE2 via CMake.`).
- In the last version they are still using `2022-04-01` https://github.com/grpc/grpc/blob/v1.70.0/bazel/grpc_deps.bzl#L127

[PKG-6904]: https://anaconda.atlassian.net/browse/PKG-6904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ