### PR TITLE
Rebuild grpc 1.78.0: fix noisy startup logs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,9 +46,14 @@ source:
     - patches/0013-update-GRPC_DLL-instances-where-necessary.patch
     - patches/0014-use-protobuf-s-libutf8_range.patch
     - patches/0015-disable-grpc-_unsecure.patch
-
+    # backport https://github.com/grpc/grpc/pull/41639
+    - patches/0016-resolve-absl-initializelog-warning.patch
+    # backport https://github.com/grpc/grpc/pull/41909
+    - patches/0017-break-out-_initialize_absl-into-separate-cython-modu.patch
+    # backport https://github.com/grpc/grpc/pull/41910
+    - patches/0018-fix-double-metric-registration-across-shared-librari.patch
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libgrpc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,13 +6,6 @@
 {% set core_major = version.split(".")[1] | int - 26 %}
 {% set core_version = core_major | string ~ ".0.0" %}
 
-{% set core_libs = ["gpr", "grpc"] %}
-{% set core_cpp_libs = ["grpc++"] %}
-{% set vendored_libs = ["address_sorting"] %}
-{% set binaries_plugin_langs = [
-    "cpp", "csharp", "node", "objective_c", "php", "python", "ruby"
-] %}
-
 package:
   name: grpc-split
   version: {{ version }}
@@ -102,41 +95,55 @@ outputs:
         - examples/
       commands:
         # libraries
-        {% for each_lib in core_libs + core_cpp_libs + vendored_libs %}
         # presence of shared libs
-        - test -f $PREFIX/lib/lib{{ each_lib }}.so              # [linux]
-        - test -f $PREFIX/lib/lib{{ each_lib }}.dylib           # [osx]
-        - if not exist %LIBRARY_BIN%\{{ each_lib }}.dll exit 1  # [win]
-        - if not exist %LIBRARY_LIB%\{{ each_lib }}.lib exit 1  # [win]
+        - test -f $PREFIX/lib/libgpr$SHLIB_EXT                     # [unix]
+        - if not exist %LIBRARY_BIN%\gpr.dll exit 1                 # [win]
+        - if not exist %LIBRARY_LIB%\gpr.lib exit 1                 # [win]
+        - test -f $PREFIX/lib/libgrpc$SHLIB_EXT                    # [unix]
+        - if not exist %LIBRARY_BIN%\grpc.dll exit 1                # [win]
+        - if not exist %LIBRARY_LIB%\grpc.lib exit 1                # [win]
+        - test -f $PREFIX/lib/libgrpc++$SHLIB_EXT                  # [unix]
+        - if not exist %LIBRARY_BIN%\grpc++.dll exit 1              # [win]
+        - if not exist %LIBRARY_LIB%\grpc++.lib exit 1              # [win]
+        - test -f $PREFIX/lib/libaddress_sorting$SHLIB_EXT          # [unix]
+        - if not exist %LIBRARY_BIN%\address_sorting.dll exit 1     # [win]
+        - if not exist %LIBRARY_LIB%\address_sorting.lib exit 1     # [win]
 
         # absence of grpc{,++}_unsecure
-        - test ! -f $PREFIX/lib/libgrpc_unsecure.so             # [linux]
-        - test ! -f $PREFIX/lib/libgrpc++_unsecure.so           # [linux]
-        - test ! -f $PREFIX/lib/libgrpc_unsecure.dylib          # [osx]
-        - test ! -f $PREFIX/lib/libgrpc++_unsecure.dylib        # [osx]
-        - if exist %LIBRARY_BIN%\grpc_unsecure.dll exit 1       # [win]
-        - if exist %LIBRARY_BIN%\grpc++_unsecure.dll exit 1     # [win]
-        - if exist %LIBRARY_LIB%\grpc_unsecure.lib exit 1       # [win]
-        - if exist %LIBRARY_LIB%\grpc++_unsecure.lib exit 1     # [win]
+        - test ! -f $PREFIX/lib/libgrpc_unsecure$SHLIB_EXT           # [unix]
+        - test ! -f $PREFIX/lib/libgrpc++_unsecure$SHLIB_EXT         # [unix]
+        - if exist %LIBRARY_BIN%\grpc_unsecure.dll exit 1           # [win]
+        - if exist %LIBRARY_BIN%\grpc++_unsecure.dll exit 1         # [win]
+        - if exist %LIBRARY_LIB%\grpc_unsecure.lib exit 1           # [win]
+        - if exist %LIBRARY_LIB%\grpc++_unsecure.lib exit 1         # [win]
 
         # absence of static libs (unix)
-        - test ! -f $PREFIX/lib/lib{{ each_lib }}.a             # [unix]
-        {% endfor %}
+        - test ! -f $PREFIX/lib/libgpr.a                            # [unix]
+        - test ! -f $PREFIX/lib/libgrpc.a                           # [unix]
+        - test ! -f $PREFIX/lib/libgrpc++.a                         # [unix]
+        - test ! -f $PREFIX/lib/libaddress_sorting.a                # [unix]
 
         # binaries
-        {% for each_lang in binaries_plugin_langs %}
-        - test -f $PREFIX/bin/grpc_{{ each_lang }}_plugin                    # [unix]
-        - if not exist %LIBRARY_BIN%\grpc_{{ each_lang }}_plugin.exe exit 1  # [win]
-        {% endfor %}
+        - test -f $PREFIX/bin/grpc_cpp_plugin                       # [unix]
+        - if not exist %LIBRARY_BIN%\grpc_cpp_plugin.exe exit 1     # [win]
+        - test -f $PREFIX/bin/grpc_csharp_plugin                    # [unix]
+        - if not exist %LIBRARY_BIN%\grpc_csharp_plugin.exe exit 1  # [win]
+        - test -f $PREFIX/bin/grpc_node_plugin                      # [unix]
+        - if not exist %LIBRARY_BIN%\grpc_node_plugin.exe exit 1    # [win]
+        - test -f $PREFIX/bin/grpc_objective_c_plugin               # [unix]
+        - if not exist %LIBRARY_BIN%\grpc_objective_c_plugin.exe exit 1  # [win]
+        - test -f $PREFIX/bin/grpc_php_plugin                       # [unix]
+        - if not exist %LIBRARY_BIN%\grpc_php_plugin.exe exit 1     # [win]
+        - test -f $PREFIX/bin/grpc_python_plugin                    # [unix]
+        - if not exist %LIBRARY_BIN%\grpc_python_plugin.exe exit 1  # [win]
+        - test -f $PREFIX/bin/grpc_ruby_plugin                      # [unix]
+        - if not exist %LIBRARY_BIN%\grpc_ruby_plugin.exe exit 1    # [win]
 
         # pkg-config (no metadata for vendored libs)
         # a number of dependencies do not have pkgconfig files on windows. e.g. re2
-        {% for each_lib in core_libs %}
-        - pkg-config --print-errors --exact-version "{{ core_version }}" {{ each_lib }} # [not win]
-        {% endfor %}
-        {% for each_lib in core_cpp_libs %}
-        - pkg-config --print-errors --exact-version "{{ version }}" {{ each_lib }} # [not win]
-        {% endfor %}
+        - pkg-config --print-errors --exact-version "{{ core_version }}" gpr     # [not win]
+        - pkg-config --print-errors --exact-version "{{ core_version }}" grpc    # [not win]
+        - pkg-config --print-errors --exact-version "{{ version }}" grpc++       # [not win]
 
         # CMake test: compile upstream example
         - ./test_grpc.sh   # [unix]
@@ -193,7 +200,6 @@ outputs:
         - python -m pip check
         - python grpcio_distribtest.py
         # the following test is flaky on pypy
-        {% if not (aarch64 or ppc64le) or python_impl == "cpython" %}
         # test actual RPC pattern (client & server); other tests did not catch
         # https://github.com/conda-forge/grpc-cpp-feedstock/issues/281
         - cd examples/python/helloworld
@@ -203,7 +209,6 @@ outputs:
         - cp ../../../test_grpcio_helloworld.py .                                # [unix]
         - copy ..\..\..\test_grpcio_helloworld.py .                              # [win]
         - python test_grpcio_helloworld.py
-        {% endif %}
   
   - name: grpcio-tools
     script: build-grpcio-tools.sh  # [not win]

--- a/recipe/patches/0016-resolve-absl-initializelog-warning.patch
+++ b/recipe/patches/0016-resolve-absl-initializelog-warning.patch
@@ -1,0 +1,139 @@
+From 869ec67659e45d2f100038dcf4f500f036e3039f Mon Sep 17 00:00:00 2001
+From: Sreenithi Sridharan <ssreenithi@google.com>
+Date: Fri, 13 Feb 2026 00:23:55 -0800
+Subject: [PATCH] [Python] Resolve absl::InitializeLog warning (#39779)
+
+Fixes #38703
+
+After Core recently changed its logging system to use absl logging, gRPC python users started seeing the warning log
+`WARNING: All log messages before absl::InitializeLog() is called are written to STDERR.`
+
+This issue especially affects users who are indirect users of the gRPC Python  library too, such as Gemini API users.
+
+`absl::InitializeLog()` is a C++ library that cannot directly be called in the Python layer. It is hence added in the Cython layer at the time of initializing.
+The Python layer so far did not have a dependency on the absl library, hence this PR also adds an external dependency on `absl/log:initialize`
+
+Design gRFC for this: grpc/proposal#505
+
+Closes #39779
+
+COPYBARA_INTEGRATE_REVIEW=https://github.com/grpc/grpc/pull/39779 from sreenithi:absl_init_log_python 59eb1e5102b99889d64757ca7382749e52a16518
+PiperOrigin-RevId: 869586957
+
+Patch adapted from https://github.com/grpc/grpc/pull/41639
+Adaptation include appplying to 1.78.0 and correctly linking to absl/log:initialize
+
+Co-authored-by: Charles Bousseau <cbousseau@anaconda.com>
+
+---
+ src/python/grpcio/grpc/_cython/BUILD.bazel    |  1 +
+ .../grpcio/grpc/_cython/_cygrpc/absl.pxd.pxi  | 18 +++++++++++++
+ .../grpcio/grpc/_cython/_cygrpc/absl.pyx.pxi  | 25 +++++++++++++++++++
+ src/python/grpcio/grpc/_cython/cygrpc.pxd     |  2 ++
+ src/python/grpcio/grpc/_cython/cygrpc.pyx     |  2 +-
+ 5 files changed, 47 insertions(+), 1 deletion(-)
+ create mode 100644 src/python/grpcio/grpc/_cython/_cygrpc/absl.pxd.pxi
+ create mode 100644 src/python/grpcio/grpc/_cython/_cygrpc/absl.pyx.pxi
+
+diff --git a/src/python/grpcio/grpc/_cython/BUILD.bazel b/src/python/grpcio/grpc/_cython/BUILD.bazel
+index e1ddc02cb1..1899c6554b 100644
+--- a/src/python/grpcio/grpc/_cython/BUILD.bazel
++++ b/src/python/grpcio/grpc/_cython/BUILD.bazel
+@@ -35,5 +35,6 @@ pyx_library(
+     defines = ["GRPC_PYTHON_BUILD=1"],
+     deps = [
+         "//:grpc",
++        "@com_google_absl//absl/log:initialize",
+     ],
+ )
+diff --git a/src/python/grpcio/grpc/_cython/_cygrpc/absl.pxd.pxi b/src/python/grpcio/grpc/_cython/_cygrpc/absl.pxd.pxi
+new file mode 100644
+index 0000000000..867d27df22
+--- /dev/null
++++ b/src/python/grpcio/grpc/_cython/_cygrpc/absl.pxd.pxi
+@@ -0,0 +1,18 @@
++# Copyright 2026 gRPC authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++# absl Utilities
++
++cdef extern from "absl/log/initialize.h" namespace "absl":
++  void InitializeLog() nogil
+diff --git a/src/python/grpcio/grpc/_cython/_cygrpc/absl.pyx.pxi b/src/python/grpcio/grpc/_cython/_cygrpc/absl.pyx.pxi
+new file mode 100644
+index 0000000000..fe60e17c71
+--- /dev/null
++++ b/src/python/grpcio/grpc/_cython/_cygrpc/absl.pyx.pxi
+@@ -0,0 +1,25 @@
++# Copyright 2026 gRPC authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++
++cdef bint _disable_absl_init_log = os.environ.get("GRPC_PYTHON_DISABLE_ABSL_INIT_LOG", "") in {"1", "t", "true", "y", "yes"}
++
++#
++# initialize absl
++#
++cdef _initialize_absl():
++  if not _disable_absl_init_log:
++    InitializeLog()
++
++_initialize_absl()
+diff --git a/src/python/grpcio/grpc/_cython/cygrpc.pxd b/src/python/grpcio/grpc/_cython/cygrpc.pxd
+index ed04119143..c894dedd8e 100644
+--- a/src/python/grpcio/grpc/_cython/cygrpc.pxd
++++ b/src/python/grpcio/grpc/_cython/cygrpc.pxd
+@@ -17,6 +17,8 @@ cimport cpython
+ 
+ include "_cygrpc/grpc.pxi"
+ 
++include "_cygrpc/absl.pxd.pxi"
++
+ include "_cygrpc/arguments.pxd.pxi"
+ include "_cygrpc/call.pxd.pxi"
+ include "_cygrpc/channel.pxd.pxi"
+diff --git a/src/python/grpcio/grpc/_cython/cygrpc.pyx b/src/python/grpcio/grpc/_cython/cygrpc.pyx
+index 3b6ae92811..64e7c12b9a 100644
+--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
++++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
+@@ -37,6 +37,7 @@ _LOGGER = logging.getLogger(__name__)
+ # TODO(atash): figure out why the coverage tool gets confused about the Cython
+ # coverage plugin when the following files don't have a '.pxi' suffix.
+ include "_cygrpc/grpc_string.pyx.pxi"
++include "_cygrpc/absl.pyx.pxi"
+ include "_cygrpc/arguments.pyx.pxi"
+ include "_cygrpc/call.pyx.pxi"
+ include "_cygrpc/channel.pyx.pxi"
+@@ -76,7 +77,6 @@ include "_cygrpc/aio/call.pyx.pxi"
+ include "_cygrpc/aio/channel.pyx.pxi"
+ include "_cygrpc/aio/server.pyx.pxi"
+ 
+-
+ #
+ # initialize gRPC
+ #
+-- 
+2.50.1 (Apple Git-155)
+

--- a/recipe/patches/0017-break-out-_initialize_absl-into-separate-cython-modu.patch
+++ b/recipe/patches/0017-break-out-_initialize_absl-into-separate-cython-modu.patch
@@ -1,0 +1,100 @@
+From 422f418559090eb91ff1609b2a7547ff9fee8b9a Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Sat, 21 Feb 2026 14:29:28 +1100
+Subject: [PATCH 16/17] break out _initialize_absl into separate cython module
+
+---
+ setup.py                                                       | 3 ++-
+ src/python/grpcio/grpc/__init__.py                             | 3 +++
+ src/python/grpcio/grpc/_cython/cygrpc.pxd                      | 2 --
+ src/python/grpcio/grpc/_cython/cygrpc.pyx                      | 1 -
+ .../_cython/{_cygrpc/absl.pxd.pxi => cygrpc_absl_init.pxd}     | 0
+ .../_cython/{_cygrpc/absl.pyx.pxi => cygrpc_absl_init.pyx}     | 2 ++
+ 6 files changed, 7 insertions(+), 4 deletions(-)
+ rename src/python/grpcio/grpc/_cython/{_cygrpc/absl.pxd.pxi => cygrpc_absl_init.pxd} (100%)
+ rename src/python/grpcio/grpc/_cython/{_cygrpc/absl.pyx.pxi => cygrpc_absl_init.pyx} (95%)
+
+diff --git a/setup.py b/setup.py
+index 38d3ab7229..460f78aa9a 100644
+--- a/setup.py
++++ b/setup.py
+@@ -305,7 +305,7 @@ if BUILD_WITH_STATIC_LIBSTDCXX:
+ 
+ CYTHON_EXTENSION_PACKAGE_NAMES = ()
+ 
+-CYTHON_EXTENSION_MODULE_NAMES = ("grpc._cython.cygrpc",)
++CYTHON_EXTENSION_MODULE_NAMES = ("grpc._cython.cygrpc", "grpc._cython.cygrpc_absl_init")
+ 
+ CYTHON_HELPER_C_FILES = ()
+ 
+@@ -505,6 +505,7 @@ def cython_extensions_and_necessity():
+                 + core_c_files
+                 + asm_files
+             ),
++            language="c++",
+             include_dirs=list(EXTENSION_INCLUDE_DIRECTORIES),
+             libraries=list(EXTENSION_LIBRARIES),
+             define_macros=list(DEFINE_MACROS),
+diff --git a/src/python/grpcio/grpc/__init__.py b/src/python/grpcio/grpc/__init__.py
+index d728bb886c..3430ef1c7f 100644
+--- a/src/python/grpcio/grpc/__init__.py
++++ b/src/python/grpcio/grpc/__init__.py
+@@ -19,6 +19,9 @@ import enum
+ import logging
+ import sys
+ 
++# ensure _initialize_absl() gets called before anything else, c.f. #38703
++import grpc._cython.cygrpc_absl_init
++
+ from grpc import _compression
+ from grpc._cython import cygrpc as _cygrpc
+ from grpc._runtime_protos import protos
+diff --git a/src/python/grpcio/grpc/_cython/cygrpc.pxd b/src/python/grpcio/grpc/_cython/cygrpc.pxd
+index c894dedd8e..ed04119143 100644
+--- a/src/python/grpcio/grpc/_cython/cygrpc.pxd
++++ b/src/python/grpcio/grpc/_cython/cygrpc.pxd
+@@ -17,8 +17,6 @@ cimport cpython
+ 
+ include "_cygrpc/grpc.pxi"
+ 
+-include "_cygrpc/absl.pxd.pxi"
+-
+ include "_cygrpc/arguments.pxd.pxi"
+ include "_cygrpc/call.pxd.pxi"
+ include "_cygrpc/channel.pxd.pxi"
+diff --git a/src/python/grpcio/grpc/_cython/cygrpc.pyx b/src/python/grpcio/grpc/_cython/cygrpc.pyx
+index 64e7c12b9a..cb0113e574 100644
+--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
++++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
+@@ -37,7 +37,6 @@ _LOGGER = logging.getLogger(__name__)
+ # TODO(atash): figure out why the coverage tool gets confused about the Cython
+ # coverage plugin when the following files don't have a '.pxi' suffix.
+ include "_cygrpc/grpc_string.pyx.pxi"
+-include "_cygrpc/absl.pyx.pxi"
+ include "_cygrpc/arguments.pyx.pxi"
+ include "_cygrpc/call.pyx.pxi"
+ include "_cygrpc/channel.pyx.pxi"
+diff --git a/src/python/grpcio/grpc/_cython/_cygrpc/absl.pxd.pxi b/src/python/grpcio/grpc/_cython/cygrpc_absl_init.pxd
+similarity index 100%
+rename from src/python/grpcio/grpc/_cython/_cygrpc/absl.pxd.pxi
+rename to src/python/grpcio/grpc/_cython/cygrpc_absl_init.pxd
+diff --git a/src/python/grpcio/grpc/_cython/_cygrpc/absl.pyx.pxi b/src/python/grpcio/grpc/_cython/cygrpc_absl_init.pyx
+similarity index 95%
+rename from src/python/grpcio/grpc/_cython/_cygrpc/absl.pyx.pxi
+rename to src/python/grpcio/grpc/_cython/cygrpc_absl_init.pyx
+index fe60e17c71..ebd5f9f2ab 100644
+--- a/src/python/grpcio/grpc/_cython/_cygrpc/absl.pyx.pxi
++++ b/src/python/grpcio/grpc/_cython/cygrpc_absl_init.pyx
+@@ -11,7 +11,9 @@
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
++# distutils: language=c++
+ 
++import os
+ 
+ cdef bint _disable_absl_init_log = os.environ.get("GRPC_PYTHON_DISABLE_ABSL_INIT_LOG", "") in {"1", "t", "true", "y", "yes"}
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/recipe/patches/0018-fix-double-metric-registration-across-shared-librari.patch
+++ b/recipe/patches/0018-fix-double-metric-registration-across-shared-librari.patch
@@ -1,0 +1,159 @@
+From db71f4d65504a541e282820fa7dc9576ebcd18cb Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Fri, 20 Mar 2026 16:40:03 +1100
+Subject: [PATCH 1/2] fix double metric registration across shared libraries
+ (libgrpc/libgrpc++)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+ResourceQuotaDomain's 5 metrics were defined as `static inline` data
+members in telemetry.h. Each DSO that transitively includes this header
+(via memory_quota.h) gets its own copy of the initializers, causing
+duplicate registration in InstrumentIndex when both libgrpc.so and
+libgrpc++.so are loaded — even though libgrpc++ never uses the metrics.
+
+Convert to function-local statics (Meyers singletons), which are only
+initialized on first call. Since libgrpc++ never calls these methods,
+no registration occurs there.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+---
+ .../chttp2/transport/chttp2_transport.cc      |  4 +-
+ .../ext/transport/chttp2/transport/parsing.cc |  2 +-
+ src/core/lib/resource_quota/memory_quota.cc   |  4 +-
+ src/core/lib/resource_quota/telemetry.h       | 67 ++++++++++++-------
+ 4 files changed, 49 insertions(+), 28 deletions(-)
+
+diff --git a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+index cdfe96fabb..df07f3b3cb 100644
+--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
++++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+@@ -3378,7 +3378,7 @@ static void benign_reclaimer_locked(
+     // Channel with no active streams: send a goaway to try and make it
+     // disconnect cleanly
+     t->resource_quota_telemetry_storage->Increment(
+-        grpc_core::ResourceQuotaDomain::kConnectionsDropped);
++        grpc_core::ResourceQuotaDomain::NumConnectionsDropped());
+     GRPC_TRACE_LOG(resource_quota, INFO)
+         << "HTTP2: " << t->peer_string.as_string_view()
+         << " - send goaway to free memory";
+@@ -3410,7 +3410,7 @@ static void destructive_reclaimer_locked(
+         << "HTTP2: " << t->peer_string.as_string_view()
+         << " - abandon stream id " << s->id;
+     t->resource_quota_telemetry_storage->Increment(
+-        grpc_core::ResourceQuotaDomain::kCallsDropped);
++        grpc_core::ResourceQuotaDomain::NumCallsDropped());
+     grpc_chttp2_cancel_stream(
+         t.get(), s,
+         grpc_error_set_int(
+diff --git a/src/core/ext/transport/chttp2/transport/parsing.cc b/src/core/ext/transport/chttp2/transport/parsing.cc
+index 279be89a1b..b6ee862e5f 100644
+--- a/src/core/ext/transport/chttp2/transport/parsing.cc
++++ b/src/core/ext/transport/chttp2/transport/parsing.cc
+@@ -676,7 +676,7 @@ static grpc_error_handle init_header_frame_parser(grpc_chttp2_transport* t,
+       // We have more streams allocated than we'd like, so apply some pushback
+       // by refusing this stream.
+       t->memory_owner.telemetry_storage()->Increment(
+-          grpc_core::ResourceQuotaDomain::kCallsRejected);
++          grpc_core::ResourceQuotaDomain::NumCallsRejected());
+       ++t->num_pending_induced_frames;
+       grpc_slice_buffer_add(
+           &t->qbuf, grpc_chttp2_rst_stream_create(
+diff --git a/src/core/lib/resource_quota/memory_quota.cc b/src/core/lib/resource_quota/memory_quota.cc
+index 4f4413184c..c18921d044 100644
+--- a/src/core/lib/resource_quota/memory_quota.cc
++++ b/src/core/lib/resource_quota/memory_quota.cc
+@@ -714,9 +714,9 @@ BasicMemoryQuota::PressureInfo BasicMemoryQuota::GetPressureInfo() {
+ 
+ void BasicMemoryQuota::PopulateGaugeData(GaugeSink<ResourceQuotaDomain>& sink) {
+   auto pressure_info = GetPressureInfo();
+-  sink.Set(ResourceQuotaDomain::kInstantaneousMemoryPressure,
++  sink.Set(ResourceQuotaDomain::DblInstantaneousMemoryPressure(),
+            pressure_info.instantaneous_pressure);
+-  sink.Set(ResourceQuotaDomain::kMemoryPressureControlValue,
++  sink.Set(ResourceQuotaDomain::DblMemoryPressureControlValue(),
+            pressure_info.pressure_control_value);
+ }
+ 
+diff --git a/src/core/lib/resource_quota/telemetry.h b/src/core/lib/resource_quota/telemetry.h
+index 87e842227c..2520e0c301 100644
+--- a/src/core/lib/resource_quota/telemetry.h
++++ b/src/core/lib/resource_quota/telemetry.h
+@@ -25,29 +25,50 @@ class ResourceQuotaDomain final : public InstrumentDomain<ResourceQuotaDomain> {
+   static constexpr absl::string_view kName = "resource_quota";
+   static constexpr auto kLabels = Labels("grpc.resource_quota");
+ 
+-  static inline const auto kCallsDropped = RegisterCounter(
+-      "grpc.resource_quota.calls_dropped",
+-      "EXPERIMENTAL.  Number of calls dropped due to resource quota "
+-      "exceeded",
+-      "calls");
+-  static inline const auto kCallsRejected = RegisterCounter(
+-      "grpc.resource_quota.calls_rejected",
+-      "EXPERIMENTAL.  Number of calls rejected due to resource quota "
+-      "exceeded",
+-      "calls");
+-  static inline const auto kConnectionsDropped = RegisterCounter(
+-      "grpc.resource_quota.connections_dropped",
+-      "EXPERIMENTAL.  Number of connections dropped due to resource quota "
+-      "exceeded",
+-      "connections");
+-  static inline const auto kInstantaneousMemoryPressure = RegisterDoubleGauge(
+-      "grpc.resource_quota.instantaneous_memory_pressure",
+-      "The current instantaneously measured memory pressure.", "ratio");
+-  static inline const auto kMemoryPressureControlValue = RegisterDoubleGauge(
+-      "grpc.resource_quota.memory_pressure_control_value",
+-      "A control value that can be used to scale buffer sizes up or down to "
+-      "adjust memory pressure to our target set point.",
+-      "ratio");
++  // Use function-local statics (Meyers singletons) instead of static inline
++  // data members to ensure lazy initialization on first use.  This avoids
++  // duplicate metric registration when the header is transitively included by
++  // translation units compiled into different shared libraries (e.g. libgrpc
++  // and libgrpc++), where each DSO's .init_array would otherwise run its own
++  // copy of the static inline initializers.
++  static const auto& NumCallsDropped() {
++    static const auto handle = RegisterCounter(
++        "grpc.resource_quota.calls_dropped",
++        "EXPERIMENTAL.  Number of calls dropped due to resource quota "
++        "exceeded",
++        "calls");
++    return handle;
++  }
++  static const auto& NumCallsRejected() {
++    static const auto handle = RegisterCounter(
++        "grpc.resource_quota.calls_rejected",
++        "EXPERIMENTAL.  Number of calls rejected due to resource quota "
++        "exceeded",
++        "calls");
++    return handle;
++  }
++  static const auto& NumConnectionsDropped() {
++    static const auto handle = RegisterCounter(
++        "grpc.resource_quota.connections_dropped",
++        "EXPERIMENTAL.  Number of connections dropped due to resource quota "
++        "exceeded",
++        "connections");
++    return handle;
++  }
++  static const auto& DblInstantaneousMemoryPressure() {
++    static const auto handle = RegisterDoubleGauge(
++        "grpc.resource_quota.instantaneous_memory_pressure",
++        "The current instantaneously measured memory pressure.", "ratio");
++    return handle;
++  }
++  static const auto& DblMemoryPressureControlValue() {
++    static const auto handle = RegisterDoubleGauge(
++        "grpc.resource_quota.memory_pressure_control_value",
++        "A control value that can be used to scale buffer sizes up or down to "
++        "adjust memory pressure to our target set point.",
++        "ratio");
++    return handle;
++  }
+ };
+ 
+ }  // namespace grpc_core
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
## grpc 1.78.0 b1

**Destination channel:** defaults

### Links
- [PKG-15613](https://anaconda.atlassian.net/browse/PKG-15613)
- [conda-forge/grpc-cpp-feedstock#423](https://github.com/conda-forge/grpc-cpp-feedstock/pull/423)
- [Upstream fix: grpc/grpc#41910](https://github.com/grpc/grpc/pull/41910)

### Explanation of changes:
- Rebuild grpc 1.78.0 to fix noisy startup logs. This addresses abseil initialize log issue.

### Context:
This is a rebuild (not a version upgrade). A full upgrade to 1.81.x would require coordinated rebuilds of tensorflow-base, grpcio-tools, and protobuf/abseil. These targeted patches fix the UX regression without that complexity.
This is also not an update to 1.78.1 as this release has been yanked upstream.

[PKG-15613]: https://anaconda.atlassian.net/browse/PKG-15613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ